### PR TITLE
Fix Python 3.7 Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,18 @@
 
 language: python
 python:
-  - 3.7
   - 3.6
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis
 
-# Command to run tests, e.g. python setup.py test
-script: tox
-
 matrix:
   include:
+    - python: 3.7
+      dist: xenial
     - python: 3.6
       env: TOXENV=flake8
+    - python: 3.6
+
+# Command to run tests, e.g. python setup.py test
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py36, py37, flake8
-skipsdist = true
 
 [travis]
 python =
@@ -15,9 +14,7 @@ commands = flake8 patch_rebaser
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
-deps =
-     .
-     pytest
+deps = pytest
 commands =
     pip install -U pip
     py.test


### PR DESCRIPTION
I thought the workaround for Travis + python 3.7 was no longer needed. I was mistaken.