### PR TITLE
Remove cleanup TODO

### DIFF
--- a/patch_rebaser/patch_rebaser.py
+++ b/patch_rebaser/patch_rebaser.py
@@ -175,9 +175,6 @@ def main():
     LOGGER.info("Rebasing %s to %s", branch, remote_branch)
     repo.branch.rebase_to_hash(branch, remote_branch)
 
-    # TODO: Clean up if rebase failed?
-    # (Clean index, workspace, checkout master)
-
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
This may help with debugging issues. DLRN will try to reset the repo to a working state during the next run, so leaving the repo as is should not cause further failures.