### PR TITLE
Clean up in case of failed rebase

### DIFF
--- a/patch_rebaser/patch_rebaser.py
+++ b/patch_rebaser/patch_rebaser.py
@@ -10,6 +10,7 @@ import logging
 import os
 
 from distroinfo import info, query
+from git_wrapper import exceptions as git_exceptions
 from git_wrapper.repo import GitRepo
 
 LOGGER = logging.getLogger("patch_rebaser")
@@ -172,10 +173,15 @@ def main():
     repo.branch.create(branch, remote_branch, reset_if_exists=True)
 
     # Rebase
-    LOGGER.info("Rebasing %s to %s", branch, commit)
-    repo.branch.rebase_to_hash(branch, commit)
-    LOGGER.info("Rebasing %s to %s", branch, remote_branch)
-    repo.branch.rebase_to_hash(branch, remote_branch)
+    try:
+        LOGGER.info("Rebasing %s to %s", branch, commit)
+        repo.branch.rebase_to_hash(branch, commit)
+        LOGGER.info("Rebasing %s to %s", branch, remote_branch)
+        repo.branch.rebase_to_hash(branch, remote_branch)
+    except git_exceptions.RebaseException:
+        LOGGER.info("Could not rebase. Cleaning up.")
+        repo.branch.abort_rebase()
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
DLRN and the script may do a hard reset before starting to operate on the repository, but that isn't enough to clean up a failed rebase state. The next run will still fail unless we explicitly abort. Also, re-raise the exception so that the failure information still gets surfaced.