### PR TITLE
Remove second rebase

### DIFF
--- a/patch_rebaser/patch_rebaser.py
+++ b/patch_rebaser/patch_rebaser.py
@@ -176,8 +176,6 @@ def main():
     try:
         LOGGER.info("Rebasing %s to %s", branch, commit)
         repo.branch.rebase_to_hash(branch, commit)
-        LOGGER.info("Rebasing %s to %s", branch, remote_branch)
-        repo.branch.rebase_to_hash(branch, remote_branch)
     except git_exceptions.RebaseException:
         LOGGER.info("Could not rebase. Cleaning up.")
         repo.branch.abort_rebase()


### PR DESCRIPTION
Because we are always rebasing on top of the latest with DLRN, the second rebase is not required at this point. By running only the first rebase, we end up in the desired state with the downstream patches standing on top of the latest upstream commit, and duplicate commits now carried upstream being dropped.

Running the second rebase puts the upstream commits back on top of the downstream ones, which is not the result we want to push back onto the patches branch.