### PR TITLE
Push rebase results to patches branch

### DIFF
--- a/patch_rebaser/patch_rebaser.ini.example
+++ b/patch_rebaser/patch_rebaser.ini.example
@@ -9,6 +9,9 @@ git_email = you@example.com
 packages_to_process =
 # Location of DLRN projects.ini file (optional)
 dlrn_projects_ini =
+# Do not force-push to remotes or do other destructive operations
+# while in development mode
+dev_mode = true
 
 [distroinfo]
 # 'patches' is the default in rdoinfo for finding the patches repo

--- a/patch_rebaser/patch_rebaser.py
+++ b/patch_rebaser/patch_rebaser.py
@@ -6,8 +6,10 @@ try:
     import configparser
 except ImportError:  # Python 2
     import ConfigParser as configparser
+from datetime import datetime
 import logging
 import os
+import time
 
 from distroinfo import info, query
 from git_wrapper import exceptions as git_exceptions
@@ -109,6 +111,119 @@ def set_up_git_config(name, email):
     os.environ["GIT_COMMITTER_EMAIL"] = email
 
 
+class Rebaser(object):
+
+    def __init__(self, repo, branch, commit, remote, timestamp,
+                 dev_mode=True, max_retries=3):
+        """Initialize the Rebaser
+
+       :param git_wrapper.GitRepo repo: An initialized GitWrapper repo
+       :param str branch: Local branch name to rebase
+       :param str commit: Commit sha to rebase to
+       :param str remote: Remote name
+       :param str timestamp: Timestamp used in tag to previous remote HEAD
+       :param bool dev_mode: Whether to run the push commands as dry-run only
+       :param int max_retries: How many retry attempts if remote changed during
+                               rebase
+        """
+        self.repo = repo
+        self.branch = branch
+        self.commit = commit
+        self.remote = remote
+        self.timestamp = timestamp
+        self.tag_name = "private-rebaser-{0}-previous".format(timestamp)
+        self.dev_mode = dev_mode
+        self.max_retries = max_retries
+
+        self.remote_branch = "{0}/{1}".format(self.remote, self.branch)
+
+    def rebase_and_update_remote(self):
+        """Rebase the local branch to the specific commit & push the result."""
+        self.repo.remote.fetch(self.remote)
+
+        # Reset the local branch to the latest
+        self.repo.branch.create(self.branch,
+                                self.remote_branch,
+                                reset_if_exists=True)
+
+        # Tag the previous branch's HEAD, before rebase
+        # TODO(jpichon): Replace repo.repo call with a proper git_wrapper call
+        tag = self.repo.repo.create_tag(self.tag_name, self.remote_branch)
+
+        # Rebase
+        self.perform_rebase()
+
+        # Check if any new changes have come in
+        self.repo.remote.fetch(self.remote)
+
+        # TODO(jpichon): Replace repo.repo call with a proper git_wrapper call,
+        # by updating git_wrapper to offer a more sensible comparison function
+        remote_tip_ref = self.repo.repo.remotes[self.remote].refs[self.branch]
+        remote_sha = remote_tip_ref.commit.hexsha
+        if tag.commit.hexsha != remote_sha:
+            if self.max_retries > 0:
+                LOGGER.info("Remote changed during rebase. Remaining "
+                            "attempts: %s", self.max_retries)
+                time.sleep(20)
+                self.max_retries -= 1
+
+                # We'll need to move the tag to the new HEAD
+                self.repo.git.tag("-d", self.tag_name)
+                self.rebase_and_update_remote()
+            else:
+                # The remote changed several times while we were trying
+                # to push the rebase result back. We stop trying for
+                # now but leave the rebase results as is, so that the
+                # build is still as up-to-date as can be. The patches
+                # branch will be temporarily out of date, but that will
+                # be corrected during the next Rebaser run.
+                LOGGER.warning(
+                    "Remote changed multiple times during rebase, not pushing."
+                    " The build will include the current rebase result."
+                )
+        else:
+            # No new stuff, push it on
+            self.update_remote_patches_branch()
+
+    def perform_rebase(self):
+        """Rebase the specific local branch to the specific commit."""
+        try:
+            LOGGER.info("Rebasing %s to %s", self.branch, self.commit)
+            self.repo.branch.rebase_to_hash(self.branch, self.commit)
+        except git_exceptions.RebaseException:
+            LOGGER.info("Could not rebase. Cleaning up.")
+            self.repo.branch.abort_rebase()
+            raise
+
+    def update_remote_patches_branch(self):
+        """Force push local patches branch to the remote repository.
+
+        Also push the tag of what was the previous head of that remote branch.
+        If in dev mode, the pushes are done in dry-run mode (-n).
+        """
+        # Do we need to push? If there are no changes between the remote
+        # and the local branch, just delete the local tag and move on.
+        if not self.repo.branch.cherry_on_head_only(
+                self.remote_branch, self.branch):
+            self.repo.git.tag("-d", self.tag_name)
+            return
+
+        if self.dev_mode:
+            LOGGER.warning("Dev mode: executing push commands in dry-run mode")
+            self.repo.git.push("-n", self.remote, self.tag_name)
+            self.repo.git.push("-nf", self.remote, self.branch)
+        else:
+            LOGGER.warning(
+                "Force-pushing {branch} to {remote} ({timestamp})".format(
+                    branch=self.branch,
+                    remote=self.remote,
+                    timestamp=self.timestamp
+                )
+            )
+            self.repo.git.push(self.remote, self.tag_name)
+            self.repo.git.push("-f", self.remote, self.branch)
+
+
 def main():
     # These variables are set up by DLRN
     user = os.environ['DLRN_USER']
@@ -119,6 +234,7 @@ def main():
 
     # The next variables come from patch_rebaser.ini
     rebaser_config = get_rebaser_config()
+    dev_mode = rebaser_config.getboolean('DEFAULT', 'dev_mode')
     remote = rebaser_config.get('DEFAULT', 'remote_name')
     git_name = rebaser_config.get('DEFAULT', 'git_name')
     git_email = rebaser_config.get('DEFAULT', 'git_email')
@@ -162,24 +278,19 @@ def main():
     repo.remote.fetch_all()
 
     # Create local patches branch
-    branch = get_patches_branch(repo, remote, dlrn_projects_ini)
+    branch_name = get_patches_branch(repo, remote, dlrn_projects_ini)
 
     # Not every project has a -patches branch for every release
-    if not branch:
+    if not branch_name:
         # TODO: (future) Create and set up patches branch
         return
 
-    remote_branch = "{remote}/{branch}".format(remote=remote, branch=branch)
-    repo.branch.create(branch, remote_branch, reset_if_exists=True)
+    # Timestamp that will be used to tag the previous branch tip
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
 
-    # Rebase
-    try:
-        LOGGER.info("Rebasing %s to %s", branch, commit)
-        repo.branch.rebase_to_hash(branch, commit)
-    except git_exceptions.RebaseException:
-        LOGGER.info("Could not rebase. Cleaning up.")
-        repo.branch.abort_rebase()
-        raise
+    # Perform rebase & force push result
+    rebaser = Rebaser(repo, branch_name, commit, remote, timestamp, dev_mode)
+    rebaser.rebase_and_update_remote()
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+#! /usr/bin/env python
+"""Base fixtures for unit tests"""
+
+from mock import Mock
+import pytest
+
+
+@pytest.fixture
+def mock_repo():
+    repo_mock = Mock()
+    repo_mock.attach_mock(Mock(), 'git')
+    return repo_mock

--- a/tests/test_patch_rebaser.py
+++ b/tests/test_patch_rebaser.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import time
+
+from git_wrapper import exceptions
 from mock import Mock
 import pytest
 
 from patch_rebaser.patch_rebaser import (
     find_patches_branch,
-    parse_distro_info_path
+    parse_distro_info_path,
+    Rebaser,
 )
 
 
@@ -41,3 +45,254 @@ def test_parse_distro_info_path():
 
     for path, result in data.items():
         assert parse_distro_info_path(path) == result
+
+
+def test_update_remote_patches_branch_no_changes_with_remote(mock_repo):
+    """
+    GIVEN Rebaser initialized correctly
+    WHEN update_remote_patches_branch is called
+    AND cherry_on_head_only returns false (indicating the local and remote
+        branches have no differences)
+    THEN git.tag is called as the tag gets deleted
+    AND git.push is not called
+    """
+    mock_repo.branch.cherry_on_head_only.return_value = False
+
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "my_tstamp", dev_mode=True)
+    rebaser.update_remote_patches_branch()
+
+    # Tag deleted and no pushes
+    mock_repo.git.tag.assert_called_once()
+    assert mock_repo.git.push.called is False
+
+
+def test_update_remote_patches_branch_with_dev_mode(mock_repo):
+    """
+    GIVEN Rebaser initialized correctly
+    WITH dev_mode set to true
+    WHEN update_remote_patches_branch is called
+    THEN git.tag is not called as the tag doesn't get deleted
+    AND git.push is called with -n argument for dry-run
+    """
+    mock_repo.branch.cherry_on_head_only.return_value = True
+
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "2019", dev_mode=True)
+    rebaser.update_remote_patches_branch()
+
+    # Tag not deleted, and pushed with -n for dry-run
+    assert mock_repo.git.tag.called is False
+    assert mock_repo.git.push.called is True
+
+    expected = [(("-n", "my_remote", "private-rebaser-2019-previous"),),
+                (("-nf", "my_remote", "my_branch"),)]
+    assert mock_repo.git.push.call_args_list == expected
+
+
+def test_update_remote_patches_branch_without_dev_mode(mock_repo):
+    """
+    GIVEN Rebaser initialized correctly
+    WITH dev_mode set to false
+    WHEN update_remote_patches_branch is called
+    THEN git.tag is not called as the tag doesn't get deleted
+    AND git.push is called without -n
+    """
+    mock_repo.branch.cherry_on_head_only.return_value = True
+
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "2019", dev_mode=False)
+    rebaser.update_remote_patches_branch()
+
+    # Tag not deleted, and pushed without -n
+    assert mock_repo.git.tag.called is False
+    assert mock_repo.git.push.called is True
+
+    expected = [(("my_remote", "private-rebaser-2019-previous"),),
+                (("-f", "my_remote", "my_branch"),)]
+    assert mock_repo.git.push.call_args_list == expected
+
+
+def test_perform_rebase(mock_repo):
+    """
+    GIVEN Rebaser initialized correctly including branch and commit
+    WHEN perform_rebase is called
+    THEN branch.rebase_to_hash is called
+    WITH the same branch and commit
+    """
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "my_tstamp", dev_mode=True)
+    rebaser.perform_rebase()
+
+    mock_repo.branch.rebase_to_hash.assert_called()
+    mock_repo.branch.rebase_to_hash.assert_called_with(
+        "my_branch", "my_commit"
+    )
+
+
+def test_perform_rebase_aborts_on_failure(mock_repo):
+    """
+    GIVEN Rebaser initialized correctly
+    WHEN rebase_to_hash fails with RebaseException
+    THEN perform_rebase also raises RebaseException
+    AND abort_rebase is called
+    """
+    mock_repo.branch.rebase_to_hash.side_effect = exceptions.RebaseException
+
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "my_tstamp", dev_mode=True)
+
+    with pytest.raises(exceptions.RebaseException):
+        rebaser.perform_rebase()
+
+    mock_repo.branch.abort_rebase.assert_called()
+
+
+def test_rebase_and_update_remote(mock_repo, monkeypatch):
+    """
+    GIVEN Rebaser initialized correctly
+    WHEN rebase_and_update_remote is called
+    THEN create_tag is called once
+    AND remote.fetch is called twice
+    AND git.push is called
+    """
+    remote, branch, remote_sha = "my_remote", "my_branch", "abc"
+
+    monkeypatch.setattr(time, 'sleep', lambda s: None)
+
+    # TODO: Mock more cleanly once git_wrapper updated with comparison function
+    mock_branch = Mock(**{'commit.hexsha': remote_sha})
+    mock_remote = Mock(refs={branch: mock_branch})
+    mock_tag = Mock(**{'commit.hexsha': remote_sha})
+    mock_repo.repo = Mock(remotes={remote: mock_remote},
+                          **{'create_tag.return_value': mock_tag})
+
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "2019", dev_mode=True)
+    rebaser.rebase_and_update_remote()
+
+    assert mock_repo.repo.create_tag.call_count == 1
+    assert mock_repo.remote.fetch.call_count == 2
+
+    expected = [(("-n", "my_remote", "private-rebaser-2019-previous"),),
+                (("-nf", "my_remote", "my_branch"),)]
+    assert mock_repo.git.push.call_args_list == expected
+
+
+def test_rebase_and_update_remote_success_after_retry(mock_repo, monkeypatch):
+    """
+    GIVEN Rebaser initialized correctly
+    WHEN rebase_and_update_remote is called
+    AND the remote changes once during the rebase
+    THEN create_tag is called twice
+    AND remote.fetch is called four times
+    AND git.tag is called once for deleting the first tag
+    AND git.push is called
+    """
+    remote, branch, remote_sha = "my_remote", "my_branch", "abc"
+
+    monkeypatch.setattr(time, 'sleep', lambda s: None)
+
+    # TODO: Mock more cleanly once git_wrapper updated with comparison function
+    mock_branch = Mock(**{'commit.hexsha': remote_sha})
+    mock_remote = Mock(refs={branch: mock_branch})
+
+    # First create_tag should return a different sha
+    mock_tag1 = Mock(**{'commit.hexsha': 'other_sha'})
+    mock_tag2 = Mock(**{'commit.hexsha': remote_sha})
+    mock_repo.repo = Mock(
+        remotes={remote: mock_remote},
+        **{'create_tag.side_effect': [mock_tag1, mock_tag2]}
+    )
+
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "my_tstamp", dev_mode=True)
+    rebaser.rebase_and_update_remote()
+
+    assert mock_repo.repo.create_tag.call_count == 2
+    assert mock_repo.remote.fetch.call_count == 4
+    mock_repo.git.tag.assert_called_once()  # Tag deletion done once
+
+    mock_repo.git.push.assert_called()
+
+
+def test_rebase_and_update_remote_stop_after_retries(mock_repo, monkeypatch):
+    """
+    GIVEN Rebaser initialized correctly
+    WHEN rebase_and_update_remote is called
+    AND the remote keeps changing during the rebase (remote head commit no
+        longer matches tag)
+    THEN create_tag is called once then once more for each retry attempt
+    AND remote.fetch is called twice then twice more per each retry attempt
+    AND git.tag is called once for every retry attempt
+    AND git.push is not called
+    """
+    remote, branch, remote_sha = "my_remote", "my_branch", "abc"
+
+    monkeypatch.setattr(time, 'sleep', lambda s: None)
+    monkeypatch.setattr(Rebaser, 'update_remote_patches_branch',
+                        lambda s: None)
+
+    # TODO: Mock more cleanly once git_wrapper updated with comparison function
+    mock_branch = Mock(**{'commit.hexsha': remote_sha})
+    mock_remote = Mock(refs={branch: mock_branch})
+
+    def retry(max_retries):
+        # Always return a different sha for the tag, as if remote kept changing
+        mock_tag = Mock(**{'commit.hexsha': 'other_sha'})
+        mock_repo.repo = Mock(remotes={remote: mock_remote},
+                              **{'create_tag.side_effect': mock_tag})
+
+        rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                          "my_tstamp", True, max_retries)
+        rebaser.rebase_and_update_remote()
+
+        assert mock_repo.repo.create_tag.call_count == 1 + max_retries
+        assert mock_repo.remote.fetch.call_count == 2 + 2 * max_retries
+        assert mock_repo.git.tag.call_count == max_retries
+        mock_repo.git.push.assert_not_called()
+
+        mock_repo.reset_mock()
+
+    retry(0)  # Only ever try once
+    retry(1)
+    retry(2)
+
+
+def test_rebase_and_update_remote_fails_next_rebase(mock_repo, monkeypatch):
+    """
+    GIVEN Rebaser initialized correctly
+    WHEN rebase_and_update_remote is called
+    AND the remote changed once during the rebase
+    AND the rebase fails with RebaseException during the second rebase
+    THEN a RebaseException is raised
+    AND create_tag is called twice
+    AND git.tag is called once for deleting the first tag
+    AND git.push is not called
+    """
+    remote, branch, remote_sha = "my_remote", "my_branch", "abc"
+    monkeypatch.setattr(time, 'sleep', lambda s: None)
+
+    mock_repo.branch.rebase_to_hash.side_effect = [None,
+                                                   exceptions.RebaseException]
+
+    # TODO: Mock more cleanly once git_wrapper updated with comparison function
+    mock_branch = Mock(**{'commit.hexsha': remote_sha})
+    mock_remote = Mock(refs={branch: mock_branch})
+    mock_tag1 = Mock(**{'commit.hexsha': 'other_sha'})
+    mock_tag2 = Mock(**{'commit.hexsha': remote_sha})
+    mock_repo.repo = Mock(
+        remotes={remote: mock_remote},
+        **{'create_tag.side_effect': [mock_tag1, mock_tag2]}
+    )
+
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "my_tstamp", dev_mode=True)
+    with pytest.raises(exceptions.RebaseException):
+        rebaser.rebase_and_update_remote()
+
+    assert mock_repo.remote.fetch.call_count == 3
+
+    assert mock_repo.repo.create_tag.call_count == 2
+    mock_repo.git.tag.assert_called_once()  # Tag deletion
+    mock_repo.git.push.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
 [testenv:flake8]
 basepython = python
 deps = flake8
-commands = flake8 patch_rebaser
+commands = flake8 patch_rebaser tests
 
 [testenv]
 setenv =


### PR DESCRIPTION
 * Include a dev mode, to test in dry-run mode without actually pushing
 * Include a retry feature, to redo the rebase if the remote changed while we were rebasing

Note: This was run once against the python-tripleoclient downstream, if you'd like to check the kind of output we'll see.