### PR TITLE
Add -patches branch when it does not exist

### DIFF
--- a/patch_rebaser/patch_rebaser.ini.example
+++ b/patch_rebaser/patch_rebaser.ini.example
@@ -12,6 +12,9 @@ dlrn_projects_ini =
 # Do not force-push to remotes or do other destructive operations
 # while in development mode
 dev_mode = true
+# Do not auto-create -patches branches when missing, unless explicitly
+# enabled
+create_patches_branch = false
 
 [distroinfo]
 # 'patches' is the default in rdoinfo for finding the patches repo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def mock_env(monkeypatch):
     monkeypatch.setitem(os.environ, 'DLRN_SOURCE_COMMIT', '123456a')
     monkeypatch.setitem(os.environ, 'DLRN_DISTROINFO_REPO', 'TEST_DI_REPO')
     monkeypatch.setitem(os.environ, 'DLRN_PACKAGE_NAME', 'TEST_PACKAGE')
+    monkeypatch.setitem(os.environ, 'PATCHES_BRANCH', 'test-patches')
 
 
 @pytest.fixture
@@ -36,6 +37,15 @@ def mock_config(datadir):
 def mock_config_with_pkgs_to_process(datadir):
     patcher = patch('os.path.realpath',
                     return_value=str(datadir/'pkgs_to_process_config.ini'))
+    patcher.start()
+    yield
+    patcher.stop()
+
+
+@pytest.fixture
+def mock_config_with_create_patches_branch(datadir):
+    patcher = patch('os.path.realpath',
+                    return_value=str(datadir/'test_config_create_branch.ini'))
     patcher.start()
     yield
     patcher.stop()

--- a/tests/test_patch_rebaser/test_config_create_branch.ini
+++ b/tests/test_patch_rebaser/test_config_create_branch.ini
@@ -5,7 +5,7 @@ git_email = "yourname@example.com"
 packages_to_process =
 dlrn_projects_ini =
 dev_mode = true
-create_patches_branch = false
+create_patches_branch = true
 
 [distroinfo]
 patches_repo_key = new-patches


### PR DESCRIPTION
When the -patches branch is not present in the repository, we may want
to create it automatically. If that is the case, we will create the
branch based on the commit received, then push it.

This commit introduces a new setting in patch_rebaser.ini, to enable
the feature if needed. It also honors the dev_mode setting, to avoid
pushing during development.