### PR TITLE
Do not force-push when creating the -patches branch

### DIFF
--- a/patch_rebaser/patch_rebaser.py
+++ b/patch_rebaser/patch_rebaser.py
@@ -54,17 +54,17 @@ def create_patches_branch(repo, commit, remote, dev_mode=True):
     # Finally, push branch before returning its name
     if dev_mode:
         LOGGER.warning("Dev mode: executing push commands in dry-run mode")
-        repo.git.push("-nf", remote, branch_name)
+        repo.git.push("-n", remote, branch_name)
     else:
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         LOGGER.warning(
-            "Force-pushing {branch} to {remote} ({timestamp})".format(
+            "Pushing {branch} to {remote} ({timestamp})".format(
                 branch=branch_name,
                 remote=remote,
                 timestamp=timestamp
             )
         )
-        repo.git.push("-f", remote, branch_name)
+        repo.git.push(remote, branch_name)
 
     return branch_name
 

--- a/tests/test_patch_rebaser.py
+++ b/tests/test_patch_rebaser.py
@@ -476,7 +476,7 @@ def test_create_branch_with_dev_mode(mock_repo, mock_env, monkeypatch):
     assert patch_rebaser.patch_rebaser._rebuild_gitreview.called is True
     assert mock_repo.git.push.called is True
 
-    expected = [(("-nf", "my_remote", "test-patches"),)]
+    expected = [(("-n", "my_remote", "test-patches"),)]
     assert mock_repo.git.push.call_args_list == expected
 
 
@@ -495,5 +495,5 @@ def test_create_branch_without_dev_mode(mock_repo, mock_env, monkeypatch):
     assert patch_rebaser.patch_rebaser._rebuild_gitreview.called is True
     assert mock_repo.git.push.called is True
 
-    expected = [(("-f", "my_remote", "test-patches"),)]
+    expected = [(("my_remote", "test-patches"),)]
     assert mock_repo.git.push.call_args_list == expected


### PR DESCRIPTION
When a -patches branch is created, we do not need to force-push,
so let's avoid it.