### PR TITLE
Add Zuul jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,32 @@
+---
+- job:
+    name: tox-flake8
+    parent: tox
+    description: |
+      Run flake8 tests
+    vars:
+      tox_envlist: flake8
+
+- job:
+    name: tox-integration-podman
+    parent: tox
+    description: |
+      Run podman-based integration tests
+    pre-run: .zuul/playbooks/pre-podman.yaml
+    vars:
+      tox_envlist: integration_podman
+
+- project:
+    name: github.com/release-depot/patch_rebaser
+    github-check:
+      jobs:
+        - tox-py27:
+            nodeset: rdo-centos-7
+        - tox-py36:
+            nodeset: rdo-centos-8
+        - tox-py37:
+            nodeset: single-fedora-31-node
+        - tox-flake8:
+            nodeset: rdo-centos-8
+        - tox-integration-podman:
+            nodeset: single-fedora-31-node

--- a/.zuul/playbooks/pre-podman.yaml
+++ b/.zuul/playbooks/pre-podman.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Install podman
+      package:
+        name: podman
+        state: present
+      become: true

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,11 @@ commands =
     /usr/bin/find . -name '*.pyc' -delete  # Avoid issues with pytests conf file discovery
     /usr/bin/sudo docker build -t patch_rebaser_integration_tests .
     /usr/bin/sudo docker run patch_rebaser_integration_tests /bin/sh -c "pytest -k integration_tests integration_tests"  # Ensure we only run the integration tests
+
+[testenv:integration_podman]
+commands =
+    /usr/bin/find . -name '*.pyc' -delete  # Avoid issues with pytests conf file discovery
+    /usr/bin/podman build -t patch_rebaser_integration_tests .
+    /usr/bin/podman run patch_rebaser_integration_tests /bin/sh -c "pytest -k integration_tests integration_tests"  # Ensure we only run the integration tests
+passenv =
+	HOME


### PR DESCRIPTION
This commit adds the required jobs to integrate with Zuul. It is
also adding an "integration_podman" test environment to tox.ini,
so we can run the integration tests on an environment providing
podman but not docker.