### PR TITLE
Improve release detection from branch with sub-releases

### DIFF
--- a/patch_rebaser/patch_rebaser.py
+++ b/patch_rebaser/patch_rebaser.py
@@ -95,7 +95,14 @@ def get_patches_branch(repo, remote, dlrn_projects_ini):
 
 def get_release_from_branch_name(branch_name):
     try:
-        return branch_name.split('-')[1]
+        release = branch_name.split('-')[1]
+        # So branch names like rhos-13.0-octavia-trunk-patches will return
+        # 13.0-octavia
+        post_release = branch_name.split('-')[2]
+        if post_release != 'trunk' and post_release != 'patches':
+            return '%s-%s' % (release, post_release)
+        else:
+            return release
     except IndexError:
         return 'Unknown'
 

--- a/tests/test_patch_rebaser.py
+++ b/tests/test_patch_rebaser.py
@@ -510,7 +510,10 @@ def test_get_release_from_branch_name():
         "rhos-16.1-trunk-patches": "16.1",
         "rhos-90-trunk-patches": "90",
         "rhos-10.0-patches": "10.0",
-        "my_branch": "Unknown"
+        "my_branch": "Unknown",
+        "rhos-18.0-foo-trunk-patches": "18.0-foo",
+        "rhos-13.0-octavia-patches": "13.0-octavia",
+        "rhos-10.0": "Unknown"
     }
 
     for branch, release in branches.items():


### PR DESCRIPTION
In some cases, we may have special releases that do not conform to the
<os>-<release>-<trunk|patches>-.* naming convention.

Those special cases will be <os>-<release>-<sub-release>-<trunk|patches>-.*,
and we want to be able to detect those and get the right release
to use when creating the private tags.