### PR TITLE
Push rebase results when dropping downstream-only patches

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git_wrapper>=0.2.1
+git_wrapper>=0.2.2
 Distroinfo>=0.1

--- a/tests/test_patch_rebaser.py
+++ b/tests/test_patch_rebaser.py
@@ -73,6 +73,45 @@ def test_update_remote_patches_branch_no_changes_with_remote(mock_repo):
     assert mock_repo.git.push.called is False
 
 
+def test_update_remote_patches_branch_no_changes_but_missing_commit(mock_repo):
+    """
+    GIVEN Rebaser initialized correctly
+    WHEN update_remote_patches_branch is called
+    AND cherry_on_head_only returns false (indicating the local and remote
+        branches have no differences)
+    AND branch.remote_contains returns false (indicating the remote is missing
+        an upstream commit)
+    THEN git.push is called
+    """
+    mock_repo.branch.cherry_on_head_only.return_value = False
+    mock_repo.branch.remote_contains.return_value = False
+
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "my_tstamp", dev_mode=True)
+    rebaser.update_remote_patches_branch()
+
+    assert mock_repo.git.push.called is True
+
+
+def test_update_remote_patches_branch_no_changes_and_commit_present(mock_repo):
+    """
+    GIVEN Rebaser initialized correctly
+    WHEN update_remote_patches_branch is called
+    AND cherry_on_head_only returns false (indicating the local and remote
+        branches have no differences)
+    AND branch.remote_contains returns true
+    THEN git.push is not called
+    """
+    mock_repo.branch.cherry_on_head_only.return_value = False
+    mock_repo.branch.remote_contains.return_value = True
+
+    rebaser = Rebaser(mock_repo, "my_branch", "my_commit", "my_remote",
+                      "my_tstamp", dev_mode=True)
+    rebaser.update_remote_patches_branch()
+
+    assert mock_repo.git.push.called is False
+
+
 def test_update_remote_patches_branch_with_dev_mode(mock_repo):
     """
     GIVEN Rebaser initialized correctly


### PR DESCRIPTION
Sometimes, a patch is proactively backported downstream ahead of merging upstream. When that happens, the rebase results do not get pushed because there are no functional changes between the branches as reported by the cherry command.

However, we still want to push in this case to make sure the latest commit hash is the same between upstream and downstream for consistency and because other tooling relies on that. This patch adds a check to confirm the latest upstream commit we rebased on is present on the patches remote - if it isn't, then we push regardless of the cherry results.

We still don't want to push all the time to avoid unnecessary churn (e.g. hashes for d/s patches changing after each rebase) and
meaningless tags being pushed to the remote. 
- - - -

WIP: Integration tests will fail until we get a new release of GitWrapper with https://github.com/release-depot/git_wrapper/pull/64 included. Also, would like @javierpena to have a look through the logic and confirm it makes sense with the data we get from DLRN. Thanks!