### PR TITLE
Temporarily pin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git_wrapper>=0.2.2
-Distroinfo>=0.1
+git_wrapper>=0.2.2,<=0.2.8
+Distroinfo>=0.1,<=0.5.1

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from setuptools import setup, find_packages
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
-requirements = [ 'Distroinfo>=0.1',
-                 'git_wrapper>=0.2.1' ]
+requirements = [ 'Distroinfo>=0.1,<=0.5.1',
+                 'git_wrapper>=0.2.2,<=0.2.8' ]
 
 test_requirements = [ 'mock', 'pytest', ]
 


### PR DESCRIPTION
We would like to tag a final version that is known to work with Python 2.7. However, it turns out that one of our dependencies, git_wrapper, is already incompatible with Python 2 and wasn't pinned.

This patch should be reverted afterwards.