### PR TITLE
Revert "Temporarily pin dependencies"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git_wrapper>=0.2.2,<=0.2.8
-Distroinfo>=0.1,<=0.5.1
+git_wrapper>=0.2.2
+Distroinfo>=0.1

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from setuptools import setup, find_packages
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
-requirements = [ 'Distroinfo>=0.1,<=0.5.1',
-                 'git_wrapper>=0.2.2,<=0.2.8' ]
+requirements = [ 'Distroinfo>=0.1',
+                 'git_wrapper>=0.2.2' ]
 
 test_requirements = [ 'mock', 'pytest', ]
 


### PR DESCRIPTION
This reverts commit c9ee4ea563cfc66b8a5cbbacd4d8ff88c4b0e1f8, which was added to tag a final version for Python 2.7 but is no longer necessary.