### PR TITLE
Update deprecated action versions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,44 +8,38 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+          python: ['3.8', '3.9', '3.10', '3.11', '3.12']
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
             python-version: ${{ matrix.python }}
         - name: Install Tox and any other packages
-          run: |
-            python -m pip install --upgrade pip
-            pip install tox tox-gh-actions
+          run: pip install tox
         - name: Run Tox
           run: tox -epy
     flake8:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-            python-version: 3.11
+            python-version: 3.12
         - name: Install Tox and any other packages
-          run: |
-            python -m pip install --upgrade pip
-            pip install tox tox-gh-actions
+          run: pip install tox
         - name: Lint with flake8
           run: tox -eflake8
     integration:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
-            python-version: 3.11
+            python-version: 3.12
         - name: Install Tox and any other packages
-          run: |
-            python -m pip install --upgrade pip
-            pip install tox tox-gh-actions
+          run: pip install tox
         - name: Run integration tests
           run: tox -eintegration


### PR DESCRIPTION
Github has moved workers to a new node [1], so we need to update those actions before the old node is decommissioned. Also, some minor cleanup of config and python versions.

[1] https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/