### PR TITLE
Update remote if url has changed

### DIFF
--- a/patch_rebaser/patch_rebaser.py
+++ b/patch_rebaser/patch_rebaser.py
@@ -457,8 +457,14 @@ def main():
     )
     if not patches_repo:
         return
-
-    if config.remote_name not in repo.remote.names():
+    remotes = repo.remote.names_url_dict()
+    # If the remote url has changed, we removes to re-create
+    if (config.remote_name in remotes.keys() and
+            patches_repo != remotes[config.remote_name]):
+        repo.remote.remove(config.remote_name)
+        remotes = repo.remote.names_url_dict()
+    # Create the remote if it doesn't exist
+    if config.remote_name not in remotes.keys():
         if not repo.remote.add(config.remote_name, patches_repo):
             raise Exception(
                 "Could not add remote {0} ({1})".format(config.remote_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git_wrapper>=0.2.2
+git_wrapper>=0.2.11
 Distroinfo>=0.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 requirements = [ 'Distroinfo>=0.1',
-                 'git_wrapper>=0.2.2' ]
+                 'git_wrapper>=0.2.11' ]
 
 test_requirements = [ 'mock', 'pytest', ]
 

--- a/tests/test_patch_rebaser.py
+++ b/tests/test_patch_rebaser.py
@@ -354,6 +354,27 @@ def test_main_function(mock_env, mock_config, monkeypatch):
         'private-rebaser-16.1-') is True
 
 
+def test_main_function_update_remote_url(mock_env, mock_config, monkeypatch):
+    """
+    GIVEN a valid patch_rebaser configuration and environment
+    WHEN main() is called
+    AND remote url has changed
+    THEN the remote.remove method is called
+    """
+    repo = MagicMock()
+    monkeypatch.setattr(repo.remote, 'names_url_dict',
+                        lambda: {"test_remote_name":
+                                 "http://origin_remote.com"})
+
+    with monkeypatch.context() as m:
+        m.setattr(patch_rebaser.patch_rebaser, 'GitRepo',
+                  Mock(return_value=repo))
+        m.setattr(patch_rebaser.patch_rebaser, 'get_patches_repo',
+                  Mock(return_value="http://test_repo.com"))
+        main()
+    repo.remote.remove.assert_called_once()
+
+
 def test_packages_to_process_skips_packages_not_in_the_list(
         mock_env, mock_config_with_pkgs_to_process, monkeypatch):
     """


### PR DESCRIPTION
Previously we were checking if the remote name is there to add it. Now, if the patches_repo url has changed, but we maintain the same remote_name, this is updated.

For doing this, we just check if the remote_name exists and if the patches_repo differs from its value. If so, we just remove the remote so next line below it'd recreate it.

Not it's based on new git_wrapper version that allows to return the remote dict with its value but also to remove the remote.

Requires: https://github.com/release-depot/git_wrapper/pull/114